### PR TITLE
chore: reduce Sentry sample rates to production-appropriate levels an…

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -4,14 +4,10 @@ import { dev } from '$app/environment';
 
 Sentry.init({
   dsn: 'https://a5831fe9174e1bb01a828906b51574ba@o4509011200704512.ingest.us.sentry.io/4509183525322752',
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.1,
   enabled: !dev,
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  // replaysSessionSampleRate: 0.1,
 
-  // TEMPORARY
-  replaysSessionSampleRate: 1.0,
+  replaysSessionSampleRate: 0.01,
 
   // If the entire session is not sampled, use the below sample rate to sample
   // sessions when an error occurs.

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -13,7 +13,7 @@ const cloudflareSentryHandle: Handle = dev
   ? ({ event, resolve }) => resolve(event)
   : initCloudflareSentryHandle({
       dsn: 'https://a5831fe9174e1bb01a828906b51574ba@o4509011200704512.ingest.us.sentry.io/4509183525322752',
-      tracesSampleRate: 1.0,
+      tracesSampleRate: 0.1,
     });
 
 const customHandle: Handle = ({ event, resolve }) => {
@@ -31,9 +31,13 @@ const customHandle: Handle = ({ event, resolve }) => {
   });
 };
 
+const sentryRequestHandle: Handle = dev
+  ? ({ event, resolve }) => resolve(event)
+  : sentryHandle();
+
 export const handle = sequence(
   cloudflareSentryHandle,
-  sentryHandle(),
+  sentryRequestHandle,
   customHandle
 );
 


### PR DESCRIPTION
…d guard sentryHandle with dev check

Lower tracesSampleRate from 100% to 10% in both client and server configs. Reduce replaysSessionSampleRate from 100% to 1% and remove obsolete comment. Wrap sentryHandle() in dev check (no-op in dev, full init in production) matching cloudflareSentryHandle pattern to prevent unnecessary initialization overhead during development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Reduced routine Sentry tracing and session replay sampling to limit unnecessary monitoring overhead.
  * Error-triggered session replays remain fully captured for troubleshooting.
  * Disabled Sentry request handling during development while preserving monitoring in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->